### PR TITLE
Allow structs to be passed in order to infer placeholders

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ repository = "https://github.com/bernardoamc/text-placeholder"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+# Optional dependency in order to use structs for context instead of a HashMap.
+struct_context = ["serde", "serde_json"]
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde_json = { version = "1.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ A flexible text template engine that allows templates with named placeholders wi
 Placeholders are defined by default following the handlebars syntax, but can be overriden
 with specific boundaries.
 
+In order to provide the context in which our placeholders will be replaced the following
+options are available:
+
+- Provide a HashMap and use `fill_with_hashmap` or `fill_with_hashmap_strict`
+- Provide a Struct and use `fill_with_struct` or `fill_with_struct_strict`
+  - :warning: This is an optional feature that depends on `serde` and `serde_json` :warning:
+
 ## Example
 
 ```rust
@@ -17,18 +24,17 @@ let mut table = HashMap::new();
 table.insert("first", "text");
 table.insert("second", "placeholder");
 
-assert_eq!(default_template.fill_in(&table), "Hello text placeholder!");
+assert_eq!(default_template.fill_with_hashmap(&table), "Hello text placeholder!");
 
 // We can also specify our own boundaries:
 
 let custom_template = Template::new_with_placeholder("Hello $[first]] $[second]!", "$[", "]");
 
-assert_eq!(default_template.fill_in(&table), "Hello text placeholder!");
+assert_eq!(default_template.fill_with_hashmap(&table), "Hello text placeholder!");
 ```
 
 ## Roadmap
 
-- Allow named arguments to be resolved through a struct.
-- Implement a `fill_in` that returns errors when a named argument cannot be found.
+- Allow objects that implement trait `std::ops::Index` instead of depending on a HashMap.
 
-_This project is based on the awesome [text-template](https://gitlab.com/boeckmann/text-template) repository._
+_This project is inspired by the awesome [text-template](https://gitlab.com/boeckmann/text-template) repository._

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,48 @@
+use std::fmt;
+
+use std::error::Error as StdError;
+
+#[cfg(feature = "struct_context")]
+use serde_json::Error as SerdeJsonError;
+
+pub type Result<T> = ::std::result::Result<T, Error>;
+
+#[derive(Debug)]
+pub enum Error {
+    PlaceholderError(String),
+    #[cfg(feature = "struct_context")]
+    SerdeError(SerdeJsonError),
+}
+
+#[cfg(feature = "struct_context")]
+impl From<SerdeJsonError> for Error {
+    fn from(err: SerdeJsonError) -> Error {
+        Error::SerdeError(err)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::PlaceholderError(msg) => {
+                write!(f, "Error while replacing placeholder. Reason: {}", msg)
+            }
+            #[cfg(feature = "struct_context")]
+            Error::SerdeError(err) => write!(
+                f,
+                "Error while converting the context to a serde_json::Value. Error: {}",
+                err
+            ),
+        }
+    }
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        match self {
+            Error::PlaceholderError(_) => "PlaceholderError",
+            #[cfg(feature = "struct_context")]
+            Error::SerdeError(_) => "SerdeError",
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,16 +17,24 @@
 //!     table.insert("first", "text");
 //!     table.insert("second", "placeholder");
 //!
-//!     assert_eq!(default_template.fill_in(&table), "Hello text placeholder!");
+//!     assert_eq!(default_template.fill_with_hashmap(&table), "Hello text placeholder!");
 //!
 //!     // We can also specify our own boundaries:
 //!
 //!     let custom_template = Template::new_with_placeholder("Hello $[first]] $[second]!", "$[", "]");
 //!
-//!     assert_eq!(default_template.fill_in(&table), "Hello text placeholder!");
+//!     assert_eq!(default_template.fill_with_hashmap(&table), "Hello text placeholder!");
 
 mod parser;
 use parser::{Parser, Token};
+
+mod error;
+use error::{Error, Result};
+
+#[cfg(feature = "struct_context")]
+extern crate serde_json;
+#[cfg(feature = "struct_context")]
+use serde::Serialize;
 
 use std::collections::HashMap;
 
@@ -57,25 +65,122 @@ impl<'t> Template<'t> {
         }
     }
 
-    /// Generates a string using the `replacements` HashMap to replace
-    /// our named placeholders within our Template.
-    pub fn fill_in(&self, replacements: &HashMap<&str, &str>) -> String {
+    /// Fill the template's placeholders using the provided `replacements HashMap`
+    /// in order to to infer values for the named placeholders.
+    ///
+    /// Placeholders without an associated value will be replaced with an empty string.
+    ///
+    /// For a version that generates an error in case a placeholder is missing see
+    /// `fill_with_hashmap_strict`.
+    pub fn fill_with_hashmap(&self, replacements: &HashMap<&str, &str>) -> String {
         let mut result = String::new();
 
         for segment in &self.tokens {
             match segment {
                 Token::Text(s) => result.push_str(s),
-                Token::Placeholder(s) => {
-                    let entry = replacements.get(s);
-                    match entry {
-                        Some(value) => result.push_str(value),
-                        _ => {}
-                    }
-                }
+                Token::Placeholder(s) => match replacements.get(s) {
+                    Some(value) => result.push_str(value),
+                    _ => {}
+                },
             }
         }
 
         result
+    }
+
+    /// Fill the template's placeholders using the provided `replacements HashMap`
+    /// in order to to infer values for the named placeholders.
+    ///
+    /// Placeholders without an associated value will result in a `Error::PlaceholderError`.
+    ///
+    /// For a version that does not generate an error in case a placeholder is missing see
+    /// `fill_with_hashmap`.
+    pub fn fill_with_hashmap_strict(&self, replacements: &HashMap<&str, &str>) -> Result<String> {
+        let mut result = String::new();
+
+        for segment in &self.tokens {
+            match segment {
+                Token::Text(s) => result.push_str(s),
+                Token::Placeholder(s) => match replacements.get(s) {
+                    Some(value) => result.push_str(value),
+                    None => {
+                        let message = format!("missing value for placeholder named '{}'.", s);
+                        return Err(Error::PlaceholderError(message));
+                    }
+                },
+            }
+        }
+
+        Ok(result)
+    }
+
+    #[cfg(feature = "struct_context")]
+    /// Fill the template's placeholders using the provided `replacements struct`
+    /// in order to to infer values for the named placeholders. The provided struct
+    /// must implement `serde::Serialize`.
+    ///
+    /// Placeholders without an associated value or with values that cannot be converted
+    /// to an str will be replaced with an empty string.
+    ///
+    /// For a version that generates an error in case a placeholder is missing see
+    /// `fill_with_struct_strict`.
+    pub fn fill_with_struct<R>(&self, replacements: &R) -> Result<String>
+    where
+        R: Serialize,
+    {
+        let mut result = String::new();
+        let replacements = serde_json::to_value(replacements)?;
+
+        for segment in &self.tokens {
+            match segment {
+                Token::Text(s) => result.push_str(s),
+                Token::Placeholder(s) => match replacements.get(s) {
+                    Some(value) => result.push_str(value.as_str().unwrap_or("")),
+                    _ => {}
+                },
+            }
+        }
+
+        Ok(result)
+    }
+
+    #[cfg(feature = "struct_context")]
+    /// Fill the template's placeholders using the provided `replacements struct`
+    /// in order to to infer values for the named placeholders. The provided struct
+    /// must implement `serde::Serialize`.
+    ///
+    /// Placeholders without an associated value or with values that cannot be converted
+    /// to an str will result in a `Error::PlaceholderError`.
+    ///
+    /// For a version that does not generate an error in case a placeholder is missing see
+    /// `fill_with_struct`.
+    pub fn fill_with_struct_strict<R>(&self, replacements: &R) -> Result<String>
+    where
+        R: Serialize,
+    {
+        let mut result = String::new();
+        let replacements = serde_json::to_value(replacements)?;
+
+        for segment in &self.tokens {
+            match segment {
+                Token::Text(s) => result.push_str(s),
+                Token::Placeholder(s) => match replacements.get(s) {
+                    Some(value) => match value.as_str() {
+                        Some(value) => result.push_str(value),
+                        None => {
+                            let message = format!("missing value for placeholder named '{}'.", s);
+                            return Err(Error::PlaceholderError(message));
+                        }
+                    },
+                    None => {
+                        let message = format!("missing value for placeholder named '{}'.", s);
+                        return Err(Error::PlaceholderError(message));
+                    }
+                },
+            }
+        }
+
+        Ok(result)
     }
 }
 
@@ -84,176 +189,513 @@ mod tests {
     use super::Template;
     use std::collections::HashMap;
 
+    #[cfg(feature = "struct_context")]
+    use serde::Serialize;
+
+    // ---------------------
+    // | fill_with_hashmap |
+    // ---------------------
     #[test]
-    fn test_single_fill_in_default_no_replacements() {
+    fn test_hashmap_no_replacements() {
         let table = HashMap::new();
 
-        assert_eq!(Template::new("hello world").fill_in(&table), "hello world");
-    }
-
-    #[test]
-    fn test_single_fill_in_default_start() {
-        let mut table = HashMap::new();
-        table.insert("placeholder", "hello");
-
         assert_eq!(
-            Template::new("{{placeholder}} world").fill_in(&table),
+            Template::new("hello world").fill_with_hashmap(&table),
             "hello world"
         );
     }
 
     #[test]
-    fn test_single_fill_in_default_middle() {
+    fn test_hashmap_replacement_start_line() {
+        let mut table = HashMap::new();
+        table.insert("placeholder", "hello");
+
+        assert_eq!(
+            Template::new("{{placeholder}} world").fill_with_hashmap(&table),
+            "hello world"
+        );
+    }
+
+    #[test]
+    fn test_hashmap_replacement_middle_line() {
         let mut table = HashMap::new();
         table.insert("placeholder", "crazy");
 
         assert_eq!(
-            Template::new("hello {{placeholder}} world").fill_in(&table),
+            Template::new("hello {{placeholder}} world").fill_with_hashmap(&table),
             "hello crazy world"
         );
     }
 
     #[test]
-    fn test_single_fill_in_default_end() {
+    fn test_hashmap_replacement_end_line() {
         let mut table = HashMap::new();
         table.insert("placeholder", "world");
 
         assert_eq!(
-            Template::new("hello {{placeholder}}").fill_in(&table),
+            Template::new("hello {{placeholder}}").fill_with_hashmap(&table),
             "hello world"
         );
     }
 
     #[test]
-    fn test_multiple_fill_in_default() {
+    fn test_hashmap_multiple_replacements() {
         let mut table = HashMap::new();
         table.insert("first", "one");
         table.insert("second", "two");
         table.insert("third", "three");
 
         assert_eq!(
-            Template::new("{{first}} {{second}} {{third}}").fill_in(&table),
+            Template::new("{{first}} {{second}} {{third}}").fill_with_hashmap(&table),
             "one two three"
         );
     }
 
     #[test]
-    fn test_single_fill_in_default_incomplete_replacements_start() {
+    fn test_hashmap_missing_starting_boundaries() {
         let mut table = HashMap::new();
         table.insert("placeholder", "world");
 
         assert_eq!(
-            Template::new("hello {{placeholder").fill_in(&table),
-            "hello {{placeholder"
-        );
-    }
-
-    #[test]
-    fn test_single_fill_in_default_incomplete_replacements_end() {
-        let mut table = HashMap::new();
-        table.insert("placeholder", "world");
-
-        assert_eq!(
-            Template::new("hello placeholder}}").fill_in(&table),
+            Template::new("hello placeholder}}").fill_with_hashmap(&table),
             "hello placeholder}}"
         );
     }
 
     #[test]
-    fn test_single_fill_in_default_missing_replacements() {
+    fn test_hashmap_missing_closing_boundaries() {
+        let mut table = HashMap::new();
+        table.insert("placeholder", "world");
+
+        assert_eq!(
+            Template::new("hello {{placeholder").fill_with_hashmap(&table),
+            "hello {{placeholder"
+        );
+    }
+
+    #[test]
+    fn test_hashmap_missing_replacements() {
         let table = HashMap::new();
 
         assert_eq!(
-            Template::new("hello {{placeholder}}").fill_in(&table),
+            Template::new("hello {{placeholder}}").fill_with_hashmap(&table),
             "hello "
         );
     }
 
+    // ----------------------------
+    // | fill_with_hashmap_strict |
+    // ----------------------------
+
     #[test]
-    fn test_single_fill_in_with_placeholder_no_replacements() {
+    fn test_hashmap_strict_no_replacements() {
         let table = HashMap::new();
 
         assert_eq!(
-            Template::new_with_placeholder("hello world", "[", "]").fill_in(&table),
+            Template::new("hello world")
+                .fill_with_hashmap_strict(&table)
+                .unwrap(),
             "hello world"
         );
     }
 
     #[test]
-    fn test_single_fill_in_with_placeholder_start() {
+    fn test_hashmap_strict_replacement_start_line() {
         let mut table = HashMap::new();
         table.insert("placeholder", "hello");
 
         assert_eq!(
-            Template::new_with_placeholder("[placeholder] world", "[", "]").fill_in(&table),
+            Template::new("{{placeholder}} world")
+                .fill_with_hashmap_strict(&table)
+                .unwrap(),
             "hello world"
         );
     }
 
     #[test]
-    fn test_single_fill_in_with_placeholder_middle() {
+    fn test_hashmap_strict_replacement_middle_line() {
         let mut table = HashMap::new();
         table.insert("placeholder", "crazy");
 
         assert_eq!(
-            Template::new_with_placeholder("hello [placeholder] world", "[", "]").fill_in(&table),
+            Template::new("hello {{placeholder}} world")
+                .fill_with_hashmap_strict(&table)
+                .unwrap(),
             "hello crazy world"
         );
     }
 
     #[test]
-    fn test_single_fill_in_with_placeholder_end() {
+    fn test_hashmap_strict_replacement_end_line() {
         let mut table = HashMap::new();
         table.insert("placeholder", "world");
 
         assert_eq!(
-            Template::new_with_placeholder("hello [placeholder]", "[", "]").fill_in(&table),
+            Template::new("hello {{placeholder}}")
+                .fill_with_hashmap_strict(&table)
+                .unwrap(),
             "hello world"
         );
     }
 
     #[test]
-    fn test_multiple_fill_in_with_placeholder() {
+    fn test_hashmap_strict_multiple_replacements() {
         let mut table = HashMap::new();
         table.insert("first", "one");
         table.insert("second", "two");
         table.insert("third", "three");
 
         assert_eq!(
-            Template::new_with_placeholder("[first] [second] [third]", "[", "]").fill_in(&table),
+            Template::new("{{first}} {{second}} {{third}}")
+                .fill_with_hashmap_strict(&table)
+                .unwrap(),
             "one two three"
         );
     }
 
     #[test]
-    fn test_single_fill_in_with_placeholder_incomplete_replacements_start() {
+    fn test_hashmap_strict_missing_starting_boundaries() {
         let mut table = HashMap::new();
         table.insert("placeholder", "world");
 
         assert_eq!(
-            Template::new_with_placeholder("hello [placeholder", "[", "]").fill_in(&table),
-            "hello [placeholder"
+            Template::new("hello placeholder}}")
+                .fill_with_hashmap_strict(&table)
+                .unwrap(),
+            "hello placeholder}}"
         );
     }
 
     #[test]
-    fn test_single_fill_in_with_placeholder_incomplete_replacements_end() {
+    fn test_hashmap_strict_missing_closing_boundaries() {
         let mut table = HashMap::new();
         table.insert("placeholder", "world");
 
         assert_eq!(
-            Template::new_with_placeholder("hello placeholder]", "[", "]").fill_in(&table),
-            "hello placeholder]"
+            Template::new("hello {{placeholder")
+                .fill_with_hashmap_strict(&table)
+                .unwrap(),
+            "hello {{placeholder"
         );
     }
 
     #[test]
-    fn test_single_fill_in_with_placeholder_missing_replacements() {
+    fn test_hashmap_strict_missing_replacements() {
         let table = HashMap::new();
 
         assert_eq!(
-            Template::new_with_placeholder("hello [placeholder]", "[", "]").fill_in(&table),
+            Template::new("hello {{placeholder}}").fill_with_hashmap_strict(&table).map_err(|e| e.to_string()),
+            Err("Error while replacing placeholder. Reason: missing value for placeholder named 'placeholder'.".to_owned())
+        );
+    }
+
+    // --------------------
+    // | fill_with_struct |
+    // --------------------
+
+    #[cfg(feature = "struct_context")]
+    #[test]
+    fn test_struct_no_replacements() {
+        #[derive(Serialize)]
+        struct Context {}
+        let context = Context {};
+
+        assert_eq!(
+            Template::new("hello world")
+                .fill_with_struct(&context)
+                .unwrap(),
+            "hello world"
+        );
+    }
+
+    #[cfg(feature = "struct_context")]
+    #[test]
+    fn test_struct_replacement_start_line() {
+        #[derive(Serialize)]
+        struct Context {
+            placeholder: String,
+        }
+        let context = Context {
+            placeholder: "hello".to_string(),
+        };
+
+        assert_eq!(
+            Template::new("{{placeholder}} world")
+                .fill_with_struct(&context)
+                .unwrap(),
+            "hello world"
+        );
+    }
+
+    #[cfg(feature = "struct_context")]
+    #[test]
+    fn test_struct_replacement_middle_line() {
+        #[derive(Serialize)]
+        struct Context {
+            placeholder: String,
+        }
+        let context = Context {
+            placeholder: "crazy".to_string(),
+        };
+
+        assert_eq!(
+            Template::new("hello {{placeholder}} world")
+                .fill_with_struct(&context)
+                .unwrap(),
+            "hello crazy world"
+        );
+    }
+
+    #[cfg(feature = "struct_context")]
+    #[test]
+    fn test_struct_replacement_end_line() {
+        #[derive(Serialize)]
+        struct Context {
+            placeholder: String,
+        }
+        let context = Context {
+            placeholder: "world".to_string(),
+        };
+
+        assert_eq!(
+            Template::new("hello {{placeholder}}")
+                .fill_with_struct(&context)
+                .unwrap(),
+            "hello world"
+        );
+    }
+
+    #[cfg(feature = "struct_context")]
+    #[test]
+    fn test_struct_multiple_replacements() {
+        #[derive(Serialize)]
+        struct Context {
+            first: String,
+            second: String,
+            third: String,
+        }
+        let context = Context {
+            first: "one".to_string(),
+            second: "two".to_string(),
+            third: "three".to_string(),
+        };
+
+        assert_eq!(
+            Template::new("{{first}} {{second}} {{third}}")
+                .fill_with_struct(&context)
+                .unwrap(),
+            "one two three"
+        );
+    }
+
+    #[cfg(feature = "struct_context")]
+    #[test]
+    fn test_struct_missing_starting_boundaries() {
+        #[derive(Serialize)]
+        struct Context {
+            placeholder: String,
+        }
+        let context = Context {
+            placeholder: "world".to_string(),
+        };
+
+        assert_eq!(
+            Template::new("hello placeholder}}")
+                .fill_with_struct(&context)
+                .unwrap(),
+            "hello placeholder}}"
+        );
+    }
+
+    #[cfg(feature = "struct_context")]
+    #[test]
+    fn test_struct_missing_closing_boundaries() {
+        #[derive(Serialize)]
+        struct Context {
+            placeholder: String,
+        }
+        let context = Context {
+            placeholder: "world".to_string(),
+        };
+
+        assert_eq!(
+            Template::new("hello {{placeholder")
+                .fill_with_struct(&context)
+                .unwrap(),
+            "hello {{placeholder"
+        );
+    }
+
+    #[cfg(feature = "struct_context")]
+    #[test]
+    fn test_struct_missing_replacements() {
+        #[derive(Serialize)]
+        struct Context {
+            different: String,
+        }
+        let context = Context {
+            different: "world".to_string(),
+        };
+
+        assert_eq!(
+            Template::new("hello {{placeholder}}")
+                .fill_with_struct(&context)
+                .unwrap(),
             "hello "
+        );
+    }
+
+    // ---------------------------
+    // | fill_with_struct_strict |
+    // ---------------------------
+
+    #[cfg(feature = "struct_context")]
+    #[test]
+    fn test_struct_strict_no_replacements() {
+        #[derive(Serialize)]
+        struct Context {}
+        let context = Context {};
+
+        assert_eq!(
+            Template::new("hello world")
+                .fill_with_struct_strict(&context)
+                .unwrap(),
+            "hello world"
+        );
+    }
+
+    #[cfg(feature = "struct_context")]
+    #[test]
+    fn test_struct_strict_replacement_start_line() {
+        #[derive(Serialize)]
+        struct Context {
+            placeholder: String,
+        }
+        let context = Context {
+            placeholder: "hello".to_string(),
+        };
+
+        assert_eq!(
+            Template::new("{{placeholder}} world")
+                .fill_with_struct_strict(&context)
+                .unwrap(),
+            "hello world"
+        );
+    }
+
+    #[cfg(feature = "struct_context")]
+    #[test]
+    fn test_struct_strict_replacement_middle_line() {
+        #[derive(Serialize)]
+        struct Context {
+            placeholder: String,
+        }
+        let context = Context {
+            placeholder: "crazy".to_string(),
+        };
+
+        assert_eq!(
+            Template::new("hello {{placeholder}} world")
+                .fill_with_struct_strict(&context)
+                .unwrap(),
+            "hello crazy world"
+        );
+    }
+
+    #[cfg(feature = "struct_context")]
+    #[test]
+    fn test_struct_strict_replacement_end_line() {
+        #[derive(Serialize)]
+        struct Context {
+            placeholder: String,
+        }
+        let context = Context {
+            placeholder: "world".to_string(),
+        };
+
+        assert_eq!(
+            Template::new("hello {{placeholder}}")
+                .fill_with_struct_strict(&context)
+                .unwrap(),
+            "hello world"
+        );
+    }
+
+    #[cfg(feature = "struct_context")]
+    #[test]
+    fn test_struct_strict_multiple_replacements() {
+        #[derive(Serialize)]
+        struct Context {
+            first: String,
+            second: String,
+            third: String,
+        }
+        let context = Context {
+            first: "one".to_string(),
+            second: "two".to_string(),
+            third: "three".to_string(),
+        };
+
+        assert_eq!(
+            Template::new("{{first}} {{second}} {{third}}")
+                .fill_with_struct_strict(&context)
+                .unwrap(),
+            "one two three"
+        );
+    }
+
+    #[cfg(feature = "struct_context")]
+    #[test]
+    fn test_struct_strict_missing_starting_boundaries() {
+        #[derive(Serialize)]
+        struct Context {
+            placeholder: String,
+        }
+        let context = Context {
+            placeholder: "world".to_string(),
+        };
+
+        assert_eq!(
+            Template::new("hello placeholder}}")
+                .fill_with_struct_strict(&context)
+                .unwrap(),
+            "hello placeholder}}"
+        );
+    }
+
+    #[cfg(feature = "struct_context")]
+    #[test]
+    fn test_struct_strict_missing_closing_boundaries() {
+        #[derive(Serialize)]
+        struct Context {
+            placeholder: String,
+        }
+        let context = Context {
+            placeholder: "world".to_string(),
+        };
+
+        assert_eq!(
+            Template::new("hello {{placeholder")
+                .fill_with_struct_strict(&context)
+                .unwrap(),
+            "hello {{placeholder"
+        );
+    }
+
+    #[cfg(feature = "struct_context")]
+    #[test]
+    fn test_struct_strict_missing_replacements() {
+        #[derive(Serialize)]
+        struct Context {
+            different: String,
+        }
+        let context = Context {
+            different: "world".to_string(),
+        };
+
+        assert_eq!(
+            Template::new("hello {{placeholder}}").fill_with_struct_strict(&context).map_err(|e| e.to_string()),
+            Err("Error while replacing placeholder. Reason: missing value for placeholder named 'placeholder'.".to_owned())
         );
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,6 +3,7 @@ enum State {
     Placeholder,
 }
 
+#[derive(Clone, PartialEq, Debug)]
 pub enum Token<'t> {
     Text(&'t str),
     Placeholder(&'t str),
@@ -67,5 +68,186 @@ impl<'t> Parser<'t> {
         }
 
         token
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Parser, Token};
+
+    #[test]
+    fn test_no_boundaries_present() {
+        let tokens = Parser::new("hello world", "[", "]").parse();
+        assert_eq!(tokens, vec![Token::Text("hello world")]);
+    }
+
+    #[test]
+    fn test_boundary_begging_of_line() {
+        let tokens = Parser::new("[placeholder] text", "[", "]").parse();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Text(""),
+                Token::Placeholder("placeholder"),
+                Token::Text(" text")
+            ]
+        );
+    }
+
+    #[test]
+    fn test_boundary_middle_of_line() {
+        let tokens = Parser::new("text [placeholder] text", "[", "]").parse();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Text("text "),
+                Token::Placeholder("placeholder"),
+                Token::Text(" text")
+            ]
+        );
+    }
+
+    #[test]
+    fn test_boundary_end_of_line() {
+        let tokens = Parser::new("text [placeholder]", "[", "]").parse();
+        assert_eq!(
+            tokens,
+            vec![Token::Text("text "), Token::Placeholder("placeholder")]
+        );
+    }
+
+    #[test]
+    fn test_boundary_multiple_boundaries() {
+        let tokens = Parser::new(
+            "[placeholder] text [placeholder] test [placeholder]",
+            "[",
+            "]",
+        )
+        .parse();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Text(""),
+                Token::Placeholder("placeholder"),
+                Token::Text(" text "),
+                Token::Placeholder("placeholder"),
+                Token::Text(" test "),
+                Token::Placeholder("placeholder")
+            ]
+        );
+    }
+
+    #[test]
+    fn test_missing_boundary_start() {
+        let tokens = Parser::new("text placeholder]", "[", "]").parse();
+        assert_eq!(tokens, vec![Token::Text("text placeholder]")]);
+    }
+
+    #[test]
+    fn test_missing_boundary_end() {
+        let tokens = Parser::new("text [placeholder", "[", "]").parse();
+        assert_eq!(
+            tokens,
+            vec![Token::Text("text "), Token::Text("[placeholder")]
+        );
+    }
+
+    #[test]
+    fn test_boundary_and_missing_boundaries() {
+        let tokens = Parser::new("text [placeholder] [placeholder", "[", "]").parse();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Text("text "),
+                Token::Placeholder("placeholder"),
+                Token::Text(" "),
+                Token::Text("[placeholder")
+            ]
+        );
+    }
+
+    #[test]
+    fn test_multiple_chars_boundary_start_of_line() {
+        let tokens = Parser::new("{{placeholder}} text", "{{", "}}").parse();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Text(""),
+                Token::Placeholder("placeholder"),
+                Token::Text(" text")
+            ]
+        );
+    }
+
+    #[test]
+    fn test_multiple_chars_boundary_middle_of_line() {
+        let tokens = Parser::new("text {{placeholder}} text", "{{", "}}").parse();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Text("text "),
+                Token::Placeholder("placeholder"),
+                Token::Text(" text")
+            ]
+        );
+    }
+
+    #[test]
+    fn test_multiple_chars_boundary_end_of_line() {
+        let tokens = Parser::new("text {{placeholder}}", "{{", "}}").parse();
+        assert_eq!(
+            tokens,
+            vec![Token::Text("text "), Token::Placeholder("placeholder")]
+        );
+    }
+
+    #[test]
+    fn test_multiple_chars_boundary_multiple_boundaries() {
+        let tokens = Parser::new(
+            "{{placeholder}} text {{placeholder}} test {{placeholder}}",
+            "{{",
+            "}}",
+        )
+        .parse();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Text(""),
+                Token::Placeholder("placeholder"),
+                Token::Text(" text "),
+                Token::Placeholder("placeholder"),
+                Token::Text(" test "),
+                Token::Placeholder("placeholder")
+            ]
+        );
+    }
+
+    #[test]
+    fn test_multiple_chars_missing_boundary_start() {
+        let tokens = Parser::new("text placeholder}}", "{{", "}}").parse();
+        assert_eq!(tokens, vec![Token::Text("text placeholder}}")]);
+    }
+
+    #[test]
+    fn test_multiple_chars_missing_boundary_end() {
+        let tokens = Parser::new("text {{placeholder", "{{", "}}").parse();
+        assert_eq!(
+            tokens,
+            vec![Token::Text("text "), Token::Text("{{placeholder")]
+        );
+    }
+
+    #[test]
+    fn test_multiple_chars_boundary_and_missing_boundaries() {
+        let tokens = Parser::new("text {{placeholder}} {{placeholder", "{{", "}}").parse();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Text("text "),
+                Token::Placeholder("placeholder"),
+                Token::Text(" "),
+                Token::Text("{{placeholder")
+            ]
+        );
     }
 }


### PR DESCRIPTION
Passing a `struct` as a replacement context is an optional feature and will require `serde` and `serde_json` as dependencies.

The following functions will allow struct usage:

+ `fill_with_struct`
+ `fill_with_struct_strict`

## Running tests with features

`cargo test --all-features`

## Todo

- [x] Implement `fill_with_struct_strict`
- [x] Implement `fill_with_hashmap_strict`
- [x] Update README
- [x] Update doc tests