### PR TITLE
Convert parser into iterator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "text_placeholder"
 description = "A flexible text template engine"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Bernardo Araujo <bernardo.amc@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/bernardoamc/text-placeholder"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ let template = Template::new("Hello {{first}} {{second}}!");
 Templates use the handlebars syntax as boundaries by default, but can be overridden:
 
 ```rust
-let template = Template::new_with_placeholder("Hello $[first]] $[second]!", "$[", "]");
+let template = Template::new_with_placeholder("Hello $[first] $[second]!", "$[", "]");
 ```
 
 ## Context
@@ -75,7 +75,7 @@ This is an optional feature that depends on `serde`. In order to enable it add t
 
 ```toml
 [dependencies]
-text_placeholder = { version = "0.3.1", features = ["struct_context"] }
+text_placeholder = { version = "0.4", features = ["struct_context"] }
 ```
 
 Each placeholder should be a `field` in your `struct` with an associated `value` that can be converted into a `str`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,8 @@
 //!
 //!     assert_eq!(default_template.fill_with_hashmap(&table), "Hello text placeholder!");
 
-mod parser;
-use parser::{Parser, Token};
+mod token_iterator;
+use token_iterator::{Token, TokenIterator};
 
 mod error;
 use error::{Error, Result};
@@ -56,7 +56,8 @@ impl<'t> Template<'t> {
     /// as a named placeholder.
     pub fn new(text: &'t str) -> Self {
         Self {
-            tokens: Parser::new(text, DEFAULT_START_PLACEHOLDER, DEFAULT_END_PLACEHOLDER).parse(),
+            tokens: TokenIterator::new(text, DEFAULT_START_PLACEHOLDER, DEFAULT_END_PLACEHOLDER)
+                .collect(),
         }
     }
 
@@ -66,7 +67,7 @@ impl<'t> Template<'t> {
     /// Template::new_with_placeholder("Hello [key]!", "[", "]");
     pub fn new_with_placeholder(text: &'t str, start: &'t str, end: &'t str) -> Self {
         Self {
-            tokens: Parser::new(text, start, end).parse(),
+            tokens: TokenIterator::new(text, start, end).collect(),
         }
     }
 


### PR DESCRIPTION
This has the benefit of avoiding extra heap allocations that we were making when building the vector of tokens in the old parser.

It is also clear that we are consuming the iterator, the old parser would modify self and calling it a second time would yield nothing, which might be unexpected for callers.