### PR TITLE
Make no_std compatible and put behind feature gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --verbose
-    - name: Run tests
+    - name: Run tests with all features
       run: cargo test --all-features --verbose
+    - name: Run tests with no default features (no_std)
+      run: cargo test --no-default-features --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,12 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [features]
+default = ["std"]
+std = []
 # Optional dependency in order to use structs for context instead of a HashMap.
-struct_context = ["serde", "serde_json"]
+struct_context = ["std", "serde", "serde_json"]
 
 [dependencies]
+hashbrown = { version = "0.13.2"} # Used when std feature is not enabled
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -79,20 +79,19 @@ assert_eq!(default_template.fill_with_hashmap(&table), "Hello text placeholder!"
 
 ### Function
 
-This uses a function to generate the substitution value. The value could be
-extracted from a HashMap or BTreeMap, read from a config file or database, or
-purely computed from the key itself.
+This uses a function to generate the substitution value. The value could be extracted from a HashMap
+or BTreeMap, read from a config file or database, or purely computed from the key itself.
 
-The function takes a `key` and returns an `Option<Cow<str>>` - that is it can
-return a borrowed `&str`, an owned `String` or no value. Returning no value
-causes `fill_with_function` to fail (it's the equivalent of
-`fill_with_hashmap_strict` in this way).
+The function takes a `key` and returns an `Option<Cow<str>>` - that is it can return a borrowed
+`&str`, an owned `String` or no value. Returning no value causes `fill_with_function` to fail (it's
+the equivalent of `fill_with_hashmap_strict` in this way).
 
-The function actually a `FnMut` closure, so it can also modify external state,
-such as keeping track of which `key` values were used. `key` has a lifetime
-borrowed from the template, so it can be stored outside of the closure.
+The function actually a `FnMut` closure, so it can also modify external state, such as keeping track
+of which `key` values were used. `key` has a lifetime borrowed from the template, so it can be
+stored outside of the closure.
 
 #### Example
+
 ```rust
 use text_placeholder::Template;
 use std::borrow::Cow;

--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
 # Text Placeholder
 
-A minimal text template engine that allows named placeholders within your templates.
+Text Placeholder is a minimalistic text template engine designed for the manipulation of named
+placeholders within textual templates.
 
-There are two necessary pieces in order to parse a template:
+This library operates based on two primary elements:
 
-- Placeholders
-- Context
+- **Placeholders**: Defined markers within the text templates intended to be replaced by actual
+  content in the final rendition.
+
+- **Context**: The precise data set used for the replacement of placeholders during the template
+  rendering process.
+
+For use within a [`no_std` environment](https://docs.rust-embedded.org/book/intro/no-std.html), Text
+Placeholder can be configured by disabling
+[the default features](https://doc.rust-lang.org/cargo/reference/features.html#the-default-feature).
+This allows the library to maintain compatibility with `no_std` specifications.
 
 ## Placeholders
 
@@ -50,7 +59,7 @@ The following methods are available with a `HashMap`:
 
 ```rust
 use text_placeholder::Template;
-use std::collections::HashMap;
+use std::collections::HashMap; // or for no_std `use hashbrown::HashMap;`
 
 let default_template = Template::new("Hello {{first}} {{second}}!");
 
@@ -71,14 +80,16 @@ assert_eq!(default_template.fill_with_hashmap(&table), "Hello text placeholder!"
 
 Allow structs that implement the `serde::Serialize` trait to be used as context.
 
-This is an optional feature that depends on `serde`. In order to enable it add the following to your `Cargo.toml` file:
+This is an optional feature that depends on `serde`. In order to enable it add the following to your
+`Cargo.toml` file:
 
 ```toml
 [dependencies]
 text_placeholder = { version = "0.4", features = ["struct_context"] }
 ```
 
-Each placeholder should be a `field` in your `struct` with an associated `value` that can be converted into a `str`.
+Each placeholder should be a `field` in your `struct` with an associated `value` that can be
+converted into a `str`.
 
 The following methods are available with a `struct`:
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,13 @@
-use std::fmt;
+use alloc::string::String;
+use core::fmt;
 
+#[cfg(feature = "std")]
 use std::error::Error as StdError;
 
 #[cfg(feature = "struct_context")]
 use serde_json::Error as SerdeJsonError;
 
-pub type Result<T> = ::std::result::Result<T, Error>;
+pub type Result<T> = ::core::result::Result<T, Error>;
 
 #[derive(Debug)]
 pub enum Error {
@@ -37,6 +39,10 @@ impl fmt::Display for Error {
     }
 }
 
+// Only available when the standard library is available
+// Enable for no_std when Error trait is stabilized for no_std
+// See: https://github.com/rust-lang/rust/issues/103765
+#[cfg(feature = "std")]
 impl StdError for Error {
     fn description(&self) -> &str {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //!
 //!     assert_eq!(default_template.fill_with_hashmap(&table), "Hello text placeholder!");
 
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 
 mod token_iterator;
 use token_iterator::{Token, TokenIterator};
@@ -122,11 +122,11 @@ impl<'t> Template<'t> {
 
     /// Fill the template's placeholders using the provided `replacements`
     /// function in order to to derive values for the named placeholders.
-    /// 
+    ///
     /// `replacements` is a [`FnMut`] which may modify its environment. The
     /// `key` parameter is borrowed from `Template`, and so can be stored in the
     /// enclosing scope.
-    /// 
+    ///
     /// Returned [`Cow<str>`] may also be borrwed from the `key`, the
     /// environment, or be an owned [`String`] that's computed from the key or
     /// derived in some other way.
@@ -230,9 +230,16 @@ impl<'t> Template<'t> {
 
 #[cfg(test)]
 mod tests {
-    use super::Template;
-    use std::borrow::Cow;
+    use alloc::{
+        borrow::{Cow, ToOwned},
+        string::ToString,
+        vec::Vec,
+    };
+
+    #[cfg(feature = "std")]
     use std::collections::HashMap;
+
+    use super::Template;
 
     #[cfg(not(feature = "std"))]
     use hashbrown::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ impl<'t> Template<'t> {
             match segment {
                 Token::Text(s) => result.push_str(s),
                 Token::Placeholder(s) => match replacements(s) {
-                    Some(value) => result.push_str(&*value),
+                    Some(value) => result.push_str(&value),
                     None => {
                         let message = format!("missing value for placeholder named '{s}'.");
                         return Err(Error::PlaceholderError(message));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 //! # A minimal text template engine
 //!
 //! ## Overview
@@ -12,7 +13,11 @@
 //! ## Example
 //!
 //!     use text_placeholder::Template;
+//!     #[cfg(feature = "std")]
 //!     use std::collections::HashMap;
+//!
+//!     #[cfg(not(feature = "std"))]
+//!     use hashbrown::HashMap;
 //!
 //!     let default_template = Template::new("Hello {{first}} {{second}}!");
 //!
@@ -39,7 +44,16 @@ extern crate serde_json;
 #[cfg(feature = "struct_context")]
 use serde::Serialize;
 
+#[cfg(feature = "std")]
 use std::collections::HashMap;
+
+#[cfg(not(feature = "std"))]
+use hashbrown::HashMap;
+
+#[macro_use]
+extern crate alloc;
+
+use alloc::{string::String, vec::Vec};
 
 const DEFAULT_START_PLACEHOLDER: &str = "{{";
 const DEFAULT_END_PLACEHOLDER: &str = "}}";
@@ -193,7 +207,14 @@ impl<'t> Template<'t> {
 #[cfg(test)]
 mod tests {
     use super::Template;
+
+    use crate::alloc::{borrow::ToOwned, string::ToString};
+
+    #[cfg(feature = "std")]
     use std::collections::HashMap;
+
+    #[cfg(not(feature = "std"))]
+    use hashbrown::HashMap;
 
     #[cfg(feature = "struct_context")]
     use serde::Serialize;

--- a/src/token_iterator.rs
+++ b/src/token_iterator.rs
@@ -80,6 +80,8 @@ impl<'t> Iterator for TokenIterator<'t> {
 #[cfg(test)]
 mod tests {
     use super::{Token, TokenIterator};
+    extern crate alloc;
+    use alloc::vec::Vec;
 
     #[test]
     fn test_no_boundaries_present() {

--- a/src/token_iterator.rs
+++ b/src/token_iterator.rs
@@ -47,9 +47,9 @@ impl<'t> TokenIterator<'t> {
 
         if let Some(placeholder_index) = self.text.find(self.end) {
             token = Token::Placeholder(
-                &self.text[self.start.len()..placeholder_index]
-                    .trim_start_matches(" ")
-                    .trim_end_matches(" "),
+                self.text[self.start.len()..placeholder_index]
+                    .trim_start_matches(' ')
+                    .trim_end_matches(' '),
             );
             let new_position = placeholder_index + self.end.len();
             self.text = &self.text[new_position..];
@@ -66,7 +66,7 @@ impl<'t> Iterator for TokenIterator<'t> {
     type Item = Token<'t>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.text.len() == 0 {
+        if self.text.is_empty() {
             return None;
         }
 


### PR DESCRIPTION
Made necessary conversions. Tested for no_std and std:

1. cargo t --no-default-features
2. cargo t


----
Requesting this no_std feature for a couple use cases: embedded devices and web-assembly by https://github.com/burn-rs/burn project.